### PR TITLE
Fix default value comparison for arrays

### DIFF
--- a/src/compare.test.ts
+++ b/src/compare.test.ts
@@ -60,4 +60,40 @@ describe("isMsgDefEqual", () => {
     };
     expect(isMsgDefEqual(definition1, definition2)).toBe(false);
   });
+
+  it("should return true for matching array default values", () => {
+    const definition1: MessageDefinition = {
+      name: "definition",
+      definitions: [
+        { type: "string", isArray: true, name: "field1", defaultValue: ["a", "b"] },
+        { type: "number", isArray: true, name: "field2", defaultValue: [1, 2] },
+      ],
+    };
+    const definition2: MessageDefinition = {
+      name: "definition",
+      definitions: [
+        { type: "string", isArray: true, name: "field1", defaultValue: ["a", "b"] },
+        { type: "number", isArray: true, name: "field2", defaultValue: [1, 2] },
+      ],
+    };
+    expect(isMsgDefEqual(definition1, definition2)).toBe(true);
+  });
+
+  it("should return false for different array default values", () => {
+    const definition1: MessageDefinition = {
+      name: "definition",
+      definitions: [
+        { type: "string", isArray: true, name: "field1", defaultValue: ["a", "b"] },
+        { type: "number", isArray: true, name: "field2", defaultValue: [1, 2] },
+      ],
+    };
+    const definition2: MessageDefinition = {
+      name: "definition",
+      definitions: [
+        { type: "string", isArray: true, name: "field1", defaultValue: ["a", "b"] },
+        { type: "number", isArray: true, name: "field2", defaultValue: [1, 3] },
+      ],
+    };
+    expect(isMsgDefEqual(definition1, definition2)).toBe(false);
+  });
 });

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -1,4 +1,28 @@
-import { MessageDefinition, MessageDefinitionField } from "./types";
+import { DefaultValue, MessageDefinition, MessageDefinitionField } from "./types";
+
+/**
+ * Deep equality comparison of two DefaultValue values. Two default values are considered equal
+ * if they are both arrays and all their elements are equal, or if they are both primitives and
+ * equal.
+ *
+ * @param lhs Left-hand side of the comparison.
+ * @param rhs Right-hand side of the comparison.
+ * @returns True if the two default values are equal, false otherwise.
+ */
+function defaultValuesEqual(lhs: DefaultValue, rhs: DefaultValue): boolean {
+  if (Array.isArray(lhs) && Array.isArray(rhs)) {
+    if (lhs.length !== rhs.length) {
+      return false;
+    }
+    for (let i = 0; i < lhs.length; i++) {
+      if (lhs[i] !== rhs[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return lhs === rhs;
+}
 
 /**
  * Compares two MessageDefinitionField objects for equality. Two fields are considered equal if all
@@ -23,7 +47,7 @@ export function isMsgDefFieldEqual(
     lhs.valueText === rhs.valueText &&
     lhs.upperBound === rhs.upperBound &&
     lhs.arrayUpperBound === rhs.arrayUpperBound &&
-    lhs.defaultValue === rhs.defaultValue
+    defaultValuesEqual(lhs.defaultValue, rhs.defaultValue)
   );
 }
 


### PR DESCRIPTION
### Public-Facing Changes
- Fixes `isMsgDefEqual` for message definitions with array default values

### Description
Fixes <https://github.com/foxglove/studio/issues/6966>. `["a"] === ["a"] -> false` in JS, we need to do a deep equality check for arrays.
