### PR TITLE
Add enumType to MessageDefinitionField

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # @foxglove/message-definition
 
+[![@foxglove/message-definition on npm](https://shields.io/npm/v/@foxglove/message-definition)](https://www.npmjs.com/package/@foxglove/message-definition)
+
 > Defines common TypeScript types for message definition schemas (ROS .msg, Protobuf, FlatBuffers, IDL, PX4 ULog, JSON Schema, etc).
 
 ## Why is this useful?
 
-Several interface definition languages exist today for describing the structure of messages. These languages are often used to generate code for serialization and deserialization of messages. This package defines a common representation in TypeScript for interface definitions, sometimes referred to as message definitions, so they can be reasoned about in a generic way. A concrete example of this is in [Foxglove Studio](https://github.com/foxglove/studio), which supports many different message serializations but provides common functionality across all of them such as [Message Path Syntax](https://foxglove.dev/docs/studio/app-concepts/message-path-syntax) and structured message display.
+Several interface definition languages exist today for describing the structure of messages. These languages are often used to generate code for serialization and deserialization of messages. This package defines a common representation in TypeScript for interface definitions, sometimes referred to as message definitions, so they can be reasoned about in a generic way. A concrete example of this is in [Foxglove](https://foxglove.dev/product), which supports many different message serializations but provides common functionality across all of them such as [Message Path Syntax](https://docs.foxglove.dev/docs/visualization/message-path-syntax/) and structured message display.
 
 ## Examples
 
@@ -55,4 +57,4 @@ Note that this package only provides type definitions, not any functionality for
 
 ## Stay in touch
 
-Join our [Slack channel](https://foxglove.dev/slack) to ask questions, share feedback, and stay up to date on what our team is working on.
+Join our [Discord community](https://foxglove.dev/chat) to ask questions, share feedback, and stay up to date on what our team is working on.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/message-definition",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Defines common types for message definition schemas (ROS .msg, Protobuf, FlatBuffers, IDL, PX4 ULog, JSON Schema, etc)",
   "license": "MIT",
   "repository": {

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -40,6 +40,7 @@ export function isMsgDefFieldEqual(
     lhs.type === rhs.type &&
     lhs.name === rhs.name &&
     (lhs.isComplex ?? false) === (rhs.isComplex ?? false) &&
+    lhs.enumName === rhs.enumName &&
     (lhs.isArray ?? false) === (rhs.isArray ?? false) &&
     lhs.arrayLength === rhs.arrayLength &&
     (lhs.isConstant ?? false) === (rhs.isConstant ?? false) &&

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -40,7 +40,7 @@ export function isMsgDefFieldEqual(
     lhs.type === rhs.type &&
     lhs.name === rhs.name &&
     (lhs.isComplex ?? false) === (rhs.isComplex ?? false) &&
-    lhs.enumName === rhs.enumName &&
+    lhs.enumType === rhs.enumType &&
     (lhs.isArray ?? false) === (rhs.isArray ?? false) &&
     lhs.arrayLength === rhs.arrayLength &&
     (lhs.isConstant ?? false) === (rhs.isConstant ?? false) &&

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,10 +58,10 @@ export type MessageDefinitionField = {
    */
   isComplex?: boolean;
   /**
-   * Name of an enumeration associated with this field. The field should contain a primitive value
-   * (`isComplex !== true`).
+   * Name of an enumeration type associated with this field. The field should contain a primitive
+   * value (`isComplex !== true`).
    */
-  enumName?: string;
+  enumType?: string;
 
   /**
    * Set to true if this field is an array. For example, the following Protobuf

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,11 @@ export type MessageDefinitionField = {
    * primitive type, a custom struct).
    */
   isComplex?: boolean;
+  /**
+   * Name of an enumeration associated with this field. The field should contain a primitive value
+   * (`isComplex !== true`).
+   */
+  enumName?: string;
 
   /**
    * Set to true if this field is an array. For example, the following Protobuf
@@ -122,6 +127,7 @@ export type MessageDefinitionField = {
    * Would be represented as:
    * ```typescript
    * { type: "bool", name: "ALIVE", isConstant: true, value: true, valueText: "True" }
+   * ```
    */
   valueText?: string;
 


### PR DESCRIPTION
Adds an `enumType?: string` field to `MessageDefinitionField`.

Bumps package version to 0.4.0.