### PR TITLE
Add deprecated attribute to message definition

### DIFF
--- a/src/compare.ts
+++ b/src/compare.ts
@@ -48,6 +48,7 @@ export function isMsgDefFieldEqual(
     lhs.valueText === rhs.valueText &&
     lhs.upperBound === rhs.upperBound &&
     lhs.arrayUpperBound === rhs.arrayUpperBound &&
+    (lhs.deprecated ?? false) === (rhs.deprecated ?? false) &&
     defaultValuesEqual(lhs.defaultValue, rhs.defaultValue)
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -181,6 +181,24 @@ export type MessageDefinitionField = {
    * deserialization will differ across each interface definition language.
    */
   defaultValue?: DefaultValue;
+
+   /**
+   * Set to true if this field is marked as deprecated in the message definition.
+   *
+   * Some interface definition languages explicitly support deprecation metadata,
+   * while others do not. For example:
+   *
+   * - In **Protobuf**, fields can be declared as deprecated using the `[deprecated = true]`
+   *   annotation in the `.proto` schema, which is reflected in the field descriptor.
+   * - In **FlatBuffers**, deprecation information is available through the
+   *   reflection schema (via the `deprecated` boolean flag on a `Field` object).
+   * - Other formats (e.g., some JSON-based schemas or older ROS message formats)
+   *   might not expose deprecation data at all.
+   *
+   * This flag can be used by tools or UIs to visually indicate deprecated fields
+   * (e.g., graying them out) or to exclude them from subscriptions and validation.
+   */
+  deprecated?: boolean;
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -182,7 +182,7 @@ export type MessageDefinitionField = {
    */
   defaultValue?: DefaultValue;
 
-   /**
+  /**
    * Set to true if this field is marked as deprecated in the message definition.
    *
    * Some interface definition languages explicitly support deprecation metadata,


### PR DESCRIPTION
### Changelog
Add deprecated flag to MessageDefinitionField to represent deprecation metadata from schema definitions (e.g. Protobuf, FlatBuffer).


### Description
Added a new optional deprecated?: boolean property to MessageDefinitionField to capture schema-level deprecation information from supported encodings.
Also updated isMsgDefFieldEqual to include deprecated in equality checks for consistency across message definition comparisons.

<table><tr><th>Before</th><th>After</th></tr><tr><td>

No way to detect or visually distinguish deprecated fields in message definitions.

</td><td>

Message definitions now expose a deprecated flag, allowing UIs to detect and visually handle deprecated fields (e.g., display them as grayed out or hidden).

</td></tr></table>