### PR TITLE
Enable NPM trusted publishing with OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,4 @@ jobs:
       - run: yarn pack
       - name: Publish to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: npx npm@latest publish package.tgz --provenance --access public
+        run: npx npm@11.7.0 publish package.tgz --provenance --access public

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
       - run: yarn run build
       - run: yarn run test
 
-      - run: yarn pack
       - name: Publish to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: npx npm@11.7.0 publish package.tgz --provenance --access public
+        run: yarn npm publish --provenance --access public

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,14 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
+      contents: read
       # https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v6
       - run: corepack enable
-      - uses: actions/setup-node@v4.1.0
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.x
           registry-url: https://registry.npmjs.org
@@ -33,7 +34,4 @@ jobs:
       - run: yarn pack
       - name: Publish to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        # `yarn npm publish` does not currently support --provenance: https://github.com/yarnpkg/berry/issues/5430
-        run: npm publish package.tgz --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        run: npx npm@latest publish package.tgz --provenance --access public

--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ dist
 !.yarn/plugins
 !.yarn/sdks
 *.tgz
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/foxglove/message-definition.git"
+    "url": "git+https://github.com/foxglove/message-definition.git"
   },
   "keywords": [
     "schema",

--- a/package.json
+++ b/package.json
@@ -52,5 +52,5 @@
     "typescript": "5.9.3",
     "typescript-eslint": "8.13.0"
   },
-  "packageManager": "yarn@4.5.1"
+  "packageManager": "yarn@4.12.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5532,11 +5532,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>":
   version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=cef18b"
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/6f7e53bf0d9702350deeb6f35e08b69cbc8b958c33e0ec77bdc0ad6a6c8e280f3959dcbfde6f5b0848bece57810696489deaaa53d75de3578ff255d168c1efbd
+  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Update npm publish workflow to use OIDC trusted publishing with provenance.

## Changes
- Add `id-token: write` and `contents: read` permissions for OIDC authentication
- Use `yarn npm publish` with `--provenance` flag for supply chain security
- Remove `yarn pack` step (no longer needed with direct yarn publishing)
- Update actions to v6
- Remove `NODE_AUTH_TOKEN` secret (no longer needed with OIDC)

## Status
✅ Trusted publishing has been configured on npmjs.com for this package.